### PR TITLE
X-Amz-Date fix

### DIFF
--- a/lib/aws_auth/authorization_header.ex
+++ b/lib/aws_auth/authorization_header.ex
@@ -41,7 +41,7 @@ defmodule AWSAuth.AuthorizationHeader do
         end)
     end
 
-    amz_date = DateFormat.format!(now, "{ISOz}") |> String.replace("-", "") |> String.replace(":", "") |> String.replace(~r/\.\d*/, "")
+    amz_date = DateFormat.format!(now, "%Y%m%dT%H%M%SZ", :strftime)
     date = DateFormat.format!(now, "%Y%m%d", :strftime)
 
     scope = "#{date}/#{region}/#{service}/aws4_request"

--- a/lib/aws_auth/query_parameters.ex
+++ b/lib/aws_auth/query_parameters.ex
@@ -14,7 +14,7 @@ defmodule AWSAuth.QueryParameters do
       headers = Dict.put(headers, "host", uri.host)
     end
 
-    amz_date = DateFormat.format!(now, "{ISOz}") |> String.replace("-", "") |> String.replace(":", "")
+    amz_date = DateFormat.format!(now, "%Y%m%dT%H%M%SZ", :strftime)
     date = DateFormat.format!(now, "%Y%m%d", :strftime)
 
     scope = "#{date}/#{region}/#{service}/aws4_request"


### PR DESCRIPTION
Fixing problem with the construction of X-Amz-Date on some platforms which adds .nnn to the seconds part of the time string. AWS doesn't accept that. This is a fix for this problem.
