### PR TITLE
update timex dependency to 0.16.3, modify tests to use `Timex.Date(ts…

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule AWSAuth.Mixfile do
   end
 
   defp deps do
-    [{:timex, "~> 0.13.2"}]
+    [{:timex, "~> 0.16.2"}]
   end
 
   defp description do

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,2 @@
-%{"timex": {:hex, :timex, "0.13.2"}}
+%{"timex": {:hex, :timex, "0.16.2"},
+  "tzdata": {:hex, :tzdata, "0.1.7"}}

--- a/test/aws_auth_test.exs
+++ b/test/aws_auth_test.exs
@@ -8,7 +8,7 @@ defmodule AWSAuthTest do
       "us-east-1",
       "s3",
       HashDict.new,
-      Timex.Date.from({2013,05,24}, Timex.Date.timezone("GMT")))
+      Timex.Date.from({2013,05,24}, :utc))
 
     assert signed_request == "https://examplebucket.s3.amazonaws.com/test.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-Signature=aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404&X-Amz-SignedHeaders=host"
   end
@@ -25,7 +25,7 @@ defmodule AWSAuthTest do
       "s3",
       headers,
       "",
-      Timex.Date.from({2013,05,24}, Timex.Date.timezone("GMT")))
+      Timex.Date.from({2013,05,24}, :utc))
 
     assert signed_request == "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;range;x-amz-content-sha256;x-amz-date,Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41"
   end
@@ -43,7 +43,7 @@ defmodule AWSAuthTest do
       "s3",
       headers,
       "Welcome to Amazon S3.",
-      Timex.Date.from({2013,05,24}, Timex.Date.timezone("GMT")))
+      Timex.Date.from({2013,05,24}, :utc))
 
     assert signed_request == "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=date;host;x-amz-content-sha256;x-amz-date;x-amz-storage-class,Signature=98ad721746da40c64f1a55b78f14c238d841ea1380cd77a1b5971af0ece108bd"
   end
@@ -58,8 +58,8 @@ defmodule AWSAuthTest do
       "us-east-1",
       "s3",
       headers,
-      Timex.Date.from({2013,05,24}, Timex.Date.timezone("GMT")))
+      Timex.Date.from({2013,05,24}, :utc))
 
-    assert signed_request == "https://examplebucket.s3.amazonaws.com/test.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-Signature=f5e83a5df8c5fc898824b8c2e0def42b6ef5f6af114e86f4f2282672ff83152&X-Amz-SignedHeaders=host%3Bx-amz-acl"
+    assert signed_request == "https://examplebucket.s3.amazonaws.com/test.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-Signature=0f5e83a5df8c5fc898824b8c2e0def42b6ef5f6af114e86f4f2282672ff83152&X-Amz-SignedHeaders=host%3Bx-amz-acl"
   end
 end


### PR DESCRIPTION
…, tz)` format

One test doesn't seem to pass though, signature matches way off, not sure why yet (aka, this is my first time working with AWS auth implementation): 

```
  1) test sign_authorization_header (AWSAuthTest)
     test/aws_auth_test.exs:16
     Assertion with == failed
     code: signed_request == "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;range;x-amz-content-sha256;x-amz-date,Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41"
     lhs:  "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;range;x-amz-content-sha256;x-amz-date,Signature=841e03155e60b13f611d36217647f7b7fdf9f3129a4200c4f35d1108fb8f38d7"
     rhs:  "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;range;x-amz-content-sha256;x-amz-date,Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41"
     stacktrace:
       test/aws_auth_test.exs:30
```
