### PR TITLE
fix Timex warning from deprecated function usage

### DIFF
--- a/test/aws_auth_test.exs
+++ b/test/aws_auth_test.exs
@@ -1,7 +1,7 @@
 defmodule AWSAuthTest do
   use ExUnit.Case
 
-  @time Timex.from({2013,05,24})
+  @time Timex.date({2013,05,24})
 
   test "url signing" do
 


### PR DESCRIPTION
sorry this didn't get into that last commit. Should remove the deprecation warning.
