### PR TITLE
Remove timex

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ signed_request = AWSAuth.sign_url("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG
   "us-east-1",
   "s3",
   Map.new,
-  Timex.Date.from({2013,05,24}, Timex.Date.timezone("GMT")))
+  ~N[2013-05-24 00:00:00])
 "https://examplebucket.s3.amazonaws.com/test.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20130524%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20130524T000000Z&X-Amz-Expires=86400&X-Amz-Signature=aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404&X-Amz-SignedHeaders=host"
 ```
 
@@ -116,6 +116,6 @@ signed_request = AWSAuth.sign_authorization_header("AKIAIOSFODNN7EXAMPLE", "wJal
   "s3",
   headers,
   "Welcome to Amazon S3.",
-  Timex.Date.from({2013,05,24}, Timex.Date.timezone("GMT")))
+  ~N[2013-05-24 00:00:00])
 "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=date;host;x-amz-content-sha256;x-amz-date;x-amz-storage-class,Signature=98ad721746da40c64f1a55b78f14c238d841ea1380cd77a1b5971af0ece108bd"
 ```

--- a/lib/aws_auth.ex
+++ b/lib/aws_auth.ex
@@ -29,7 +29,7 @@ defmodule AWSAuth do
   end
 
   def sign_url(access_key, secret_key, http_method, url, region, service, headers) do
-    sign_url(access_key, secret_key, http_method, url, region, service, headers, Timex.DateTime.now)
+    sign_url(access_key, secret_key, http_method, url, region, service, headers, current_time)
   end
 
   def sign_url(access_key, secret_key, http_method, url, region, service, headers, request_time) do
@@ -74,11 +74,14 @@ defmodule AWSAuth do
   end
 
   def sign_authorization_header(access_key, secret_key, http_method, url, region, service, headers, payload) do
-    sign_authorization_header(access_key, secret_key, http_method, url, region, service, headers, payload, Timex.DateTime.now)
+    sign_authorization_header(access_key, secret_key, http_method, url, region, service, headers, payload, current_time)
   end
 
   def sign_authorization_header(access_key, secret_key, http_method, url, region, service, headers, payload, request_time) do
     AWSAuth.AuthorizationHeader.sign(access_key, secret_key, http_method, url, region, service, payload, headers, request_time)
   end
 
+  defp current_time do
+    DateTime.utc_now |> DateTime.to_naive
+  end
 end

--- a/lib/aws_auth/authorization_header.ex
+++ b/lib/aws_auth/authorization_header.ex
@@ -3,7 +3,6 @@ defmodule AWSAuth.AuthorizationHeader do
 
   #http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html
   def sign(access_key, secret_key, http_method, url, region, service, payload, headers, request_time) do
-    now = request_time
     uri = URI.parse(url)
 
     params = case uri.query do
@@ -26,15 +25,15 @@ defmodule AWSAuth.AuthorizationHeader do
 
     headers = Map.put_new(headers, "x-amz-content-sha256", payload)
 
-    amz_date = Timex.format!(now, "%Y%m%dT%H%M%SZ", :strftime)
-    date = Timex.format!(now, "%Y%m%d", :strftime)
+    amz_date = request_time |> AWSAuth.Utils.format_time
+    date = request_time |> AWSAuth.Utils.format_date
 
     scope = "#{date}/#{region}/#{service}/aws4_request"
 
     string_to_sign = AWSAuth.Utils.build_canonical_request(http_method, uri.path || "/", params, headers, payload)
     |>  AWSAuth.Utils.build_string_to_sign(amz_date, scope)
 
-    signature =  AWSAuth.Utils.build_signing_key(secret_key, date, region, service)
+    signature = AWSAuth.Utils.build_signing_key(secret_key, date, region, service)
     |>  AWSAuth.Utils.build_signature(string_to_sign)
 
     signed_headers = Enum.map(headers, fn({key, _}) -> String.downcase(key)  end)

--- a/lib/aws_auth/utils.ex
+++ b/lib/aws_auth/utils.ex
@@ -50,4 +50,18 @@ defmodule AWSAuth.Utils do
     Base.encode16(bytes, case: :lower)
   end
 
+  def format_time(time) do
+    formatted_time = time
+    |> NaiveDateTime.to_iso8601
+    |> String.replace("-", "")
+    |> String.replace(":", "")
+    formatted_time <> "Z"
+  end
+
+  def format_date(date) do
+    date
+    |> NaiveDateTime.to_date
+    |> Date.to_iso8601
+    |> String.replace("-", "")
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule AWSAuth.Mixfile do
   def project do
     [app: :aws_auth,
      version: "0.4.1",
-     elixir: "~> 1.0",
+     elixir: "~> 1.3",
      description: description,
      package: package,
      deps: deps,
@@ -14,12 +14,11 @@ defmodule AWSAuth.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :timex]]
+    [applications: [:logger]]
   end
 
   defp deps do
     [
-      {:timex, "~> 2.0"},
       {:earmark, "~> 0.2", only: :dev },
       {:ex_doc, "~> 0.11", only: :dev },
       {:excoveralls, "~> 0.4", only: :test},

--- a/test/aws_auth_test.exs
+++ b/test/aws_auth_test.exs
@@ -1,14 +1,7 @@
 defmodule AWSAuthTest do
   use ExUnit.Case
 
-  @time %Timex.DateTime{
-    year: 2013,
-    month: 5,
-    day: 24,
-    hour: 1,
-    minute: 23,
-    second: 45
-  }
+  @time ~N[2013-05-24 01:23:45]
 
   test "url signing" do
     signed_request = AWSAuth.sign_url("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",


### PR DESCRIPTION
Hey again :)

I noticed this morning that Timex 2.0 has a few dependencies, which increases the compile time for projects that use `aws_auth`. Here's the dependencies as shown by `mix deps.tree`:

```
│       └── timex ~> 2.0 (Hex package)
│           ├── combine ~> 0.7 (Hex package)
│           ├── gettext ~> 0.10 (Hex package)
│           └── tzdata ~> 0.1.8 or ~> 0.5 (Hex package)
│               └── hackney ~> 1.0 (Hex package)
│                   ├── certifi 0.4.0 (Hex package)
│                   ├── idna 1.2.0 (Hex package)
│                   ├── metrics 1.0.1 (Hex package)
│                   ├── mimerl 1.0.2 (Hex package)
│                   └── ssl_verify_fun 1.1.0 (Hex package)
```

The same goes for timex 3.0:

```
├── timex ~> 3.0 (Hex package)
│   ├── combine ~> 0.7 (Hex package)
│   ├── gettext ~> 0.10 (Hex package)
│   └── tzdata ~> 0.1.8 or ~> 0.5 (Hex package)
│       └── hackney ~> 1.0 (Hex package)
│           ├── certifi 0.4.0 (Hex package)
│           ├── idna 1.2.0 (Hex package)
│           ├── metrics 1.0.1 (Hex package)
│           ├── mimerl 1.0.2 (Hex package)
│           └── ssl_verify_fun 1.1.0 (Hex package)
```

This library only uses timex for time/date formatting, which can be accomplished using the built-in  date/time functions in Elixir 1.3+. With the timex dependency removed, then the compile time for my project is much faster.

I think this will require a major version bump for aws_auth.
