### PR TITLE
Ensure NDT with ms precision are formatted correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.6.1]
+
+### Fixed
+- Correctly handle NaiveDateTimes with ms precision (thanks to [@radar](https://github.com/radar))
+
 ## [0.6.0]
 
 ### Changed

--- a/lib/aws_auth/utils.ex
+++ b/lib/aws_auth/utils.ex
@@ -53,6 +53,8 @@ defmodule AWSAuth.Utils do
   def format_time(time) do
     formatted_time = time
     |> NaiveDateTime.to_iso8601
+    |> String.split(".")
+    |> List.first
     |> String.replace("-", "")
     |> String.replace(":", "")
     formatted_time <> "Z"

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule AWSAuth.Mixfile do
 
   def project do
     [app: :aws_auth,
-     version: "0.6.0",
+     version: "0.6.1",
      elixir: "~> 1.3",
      description: description,
      package: package,

--- a/test/aws_utils_test.exs
+++ b/test/aws_utils_test.exs
@@ -1,0 +1,8 @@
+defmodule AWSAuth.UtilsTest do
+  use ExUnit.Case
+
+  test "format_time formats a time correctly" do
+    time = AWSAuth.Utils.format_time(~N[2016-10-20 10:32:45.12345])
+    assert time == "20161020T103245Z"
+  end
+end


### PR DESCRIPTION
I was passing in an NDT with ms precision, which caused the signature string to be incorrect:

```
 %{"message" => "The request signature we calculated does not match the signature you provided. ...
```

Removing the ms precision from the time solves this issue.
