### PR TITLE
Encode each path using www form

### DIFF
--- a/lib/aws_auth/utils.ex
+++ b/lib/aws_auth/utils.ex
@@ -1,7 +1,7 @@
 defmodule AWSAuth.Utils do
   @moduledoc false
 
-  def build_canonical_request(http_method, url, params, headers, hashed_payload) do
+  def build_canonical_request(http_method, path, params, headers, hashed_payload) do
 
     query_params = URI.encode_query(params) |> String.replace("+", "%20")
 
@@ -17,7 +17,13 @@ defmodule AWSAuth.Utils do
       do: "UNSIGNED-PAYLOAD",
       else: hashed_payload
 
-    "#{http_method}\n#{URI.encode(url) |> String.replace("$", "%24")}\n#{query_params}\n#{header_params}\n\n#{signed_header_params}\n#{hashed_payload}"
+    encoded_path =
+      path
+      |> String.split("/")
+      |> Enum.map(fn (segment) -> URI.encode_www_form(segment) end)
+      |> Enum.join("/")
+
+    "#{http_method}\n#{encoded_path}\n#{query_params}\n#{header_params}\n\n#{signed_header_params}\n#{hashed_payload}"
   end
 
   def build_string_to_sign(canonical_request, timestamp, scope) do

--- a/test/aws_utils_test.exs
+++ b/test/aws_utils_test.exs
@@ -1,7 +1,24 @@
 defmodule AWSAuth.UtilsTest do
   use ExUnit.Case
 
-  test "format_time formats a time correctly" do
+  test "build_canonical_request/5 builds correct AWS request representation" do
+    canonical_request = AWSAuth.Utils.build_canonical_request("GET", "path/subpath", %{ "a" => 1, "b" => "2", "c" => 1.0},
+                                                              %{ "a" => "1", "b" => "2" }, "hashed_payload")
+    assert canonical_request == "GET\npath/subpath\na=1&b=2&c=1.0\na:1\nb:2\n\na;b\nhashed_payload"
+  end
+
+  test "build_canonical_request/5 builds correct AWS request representation with unsigned hash_payload" do
+    canonical_request = AWSAuth.Utils.build_canonical_request("GET", "path/subpath", %{ "a" => 1, "b" => "2", "c" => 1.0},
+                                                              %{ "a" => "1", "b" => "2" }, :unsigned)
+    assert canonical_request == "GET\npath/subpath\na=1&b=2&c=1.0\na:1\nb:2\n\na;b\nUNSIGNED-PAYLOAD"
+  end
+
+  test "build_canonical_request/5 builds correct AWS request representation correctly escaped" do
+    canonical_request = AWSAuth.Utils.build_canonical_request("GET", "path/subpath/!@#$%^&*()-_=+?,.<>;:'\"[]{}|\\~`", %{}, %{}, "")
+    assert canonical_request == "GET\npath/subpath/%21%40%23%24%25%5E%26%2A%28%29-_%3D%2B%3F%2C.%3C%3E%3B%3A%27%22%5B%5D%7B%7D%7C%5C~%60\n\n\n\n\n"
+  end
+
+  test "format_time/1 formats a time correctly" do
     time = AWSAuth.Utils.format_time(~N[2016-10-20 10:32:45.12345])
     assert time == "20161020T103245Z"
   end


### PR DESCRIPTION
Fixes #33

URI.encode_www_form escapes special characters, which is what AWS does