### PR TITLE
Erlang 24 support

### DIFF
--- a/lib/aws_auth/utils.ex
+++ b/lib/aws_auth/utils.ex
@@ -49,7 +49,11 @@ defmodule AWSAuth.Utils do
   end
 
   def hmac_sha256(key, data) do
-    :crypto.hmac(:sha256, key, data)
+    if function_exported?(:crypto, :mac, 4) do
+      :crypto.mac(:hmac, :sha256, key, data)
+    else
+      :crypto.hmac(:sha256, key, data)
+    end
   end
 
   def bytes_to_string(bytes) do


### PR DESCRIPTION
To support :crypto.mac/4 in Erlang 24 with fallback compatibility 