### PR TITLE
Use :crypto.mac/4 when available

### DIFF
--- a/lib/aws_auth/utils.ex
+++ b/lib/aws_auth/utils.ex
@@ -49,7 +49,11 @@ defmodule AWSAuth.Utils do
   end
 
   def hmac_sha256(key, data) do
-    :crypto.hmac(:sha256, key, data)
+    if Code.ensure_loaded?(:crypto) and function_exported?(:crypto, :mac, 4) do
+      :crypto.mac(:hmac, :sha256, key, data)
+    else
+      :crypto.hmac(:sha256, key, data)
+    end
   end
 
   def bytes_to_string(bytes) do

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule AWSAuth.Mixfile do
   end
 
   def application do
-    [applications: [:logger]]
+    [applications: [:logger, :crypto]]
   end
 
   defp deps do


### PR DESCRIPTION
For the latest versions of Erlang `:crypto.hmac/3` fails. This pr includes a check of the availability of `:crypto.mac/4` when hashing a payload